### PR TITLE
Problem with fetching data from 'BINARY' fields.

### DIFF
--- a/lib/geventmysql/geventmysql._mysql.pyx
+++ b/lib/geventmysql/geventmysql._mysql.pyx
@@ -995,7 +995,8 @@ cdef class PacketReader:
                         if row[i] is not None and (self.encoding or self.use_unicode):
                             bytes = fields[i][2]
                             nr = ord(bytes[1]) << 8 | ord(bytes[0])
-                            row[i] = row[i].decode(charset_nr[nr])
+                            if charset_nr[nr] != 'binary':
+                                row[i] = row[i].decode(charset_nr[nr])
                             if not self.use_unicode:
                                 row[i] = row[i].encode(self.encoding)
 

--- a/test/testmysql.py
+++ b/test/testmysql.py
@@ -602,7 +602,47 @@ class TestMySQL(unittest.TestCase):
             result = cur.fetchall()
             self.assertEquals(result, expected)
 
+    def testBinary(self):
+        peacesign_binary = "\xe2\x98\xae"
+        peacesign_binary2 = "\xe2\x98\xae" * 10
 
+        cnn = dbapi.connect(host = DB_HOST, user = DB_USER,
+                            password = DB_PASSWD, db = DB_DB,
+                            charset = 'latin-1', use_unicode = True)
+
+        cur = cnn.cursor()
+        cur.execute("drop table if exists tblbin")
+        cur.execute("create table tblbin (test_id int(11) DEFAULT NULL, test_binary VARBINARY(30) DEFAULT NULL) ENGINE=MyISAM DEFAULT CHARSET=utf8")
+
+        cur.execute("insert into tblbin (test_id, test_binary) values (%s, %s)", (1, peacesign_binary))
+        cur.execute("insert into tblbin (test_id, test_binary) values (%s, %s)", (2, peacesign_binary2))
+
+        cur.execute("select test_id, test_binary from tblbin")
+        result = cur.fetchall()
+
+        # We expect binary strings back
+        self.assertEquals([(1, peacesign_binary),(2, peacesign_binary2)], result)
+
+    def testBlob(self):
+        peacesign_binary = "\xe2\x98\xae"
+        peacesign_binary2 = "\xe2\x98\xae" * 1024
+
+        cnn = dbapi.connect(host = DB_HOST, user = DB_USER,
+                            password = DB_PASSWD, db = DB_DB,
+                            charset = 'latin-1', use_unicode = True)
+
+        cur = cnn.cursor()
+        cur.execute("drop table if exists tblblob")
+        cur.execute("create table tblblob (test_id int(11) DEFAULT NULL, test_blob BLOB DEFAULT NULL) ENGINE=MyISAM DEFAULT CHARSET=utf8")
+
+        cur.execute("insert into tblblob (test_id, test_blob) values (%s, %s)", (1, peacesign_binary))
+        cur.execute("insert into tblblob (test_id, test_blob) values (%s, %s)", (2, peacesign_binary2))
+
+        cur.execute("select test_id, test_blob from tblblob")
+        result = cur.fetchall()
+
+        # We expect binary strings back
+        self.assertEquals([(1, peacesign_binary),(2, peacesign_binary2)], result)
 
 
 


### PR DESCRIPTION
I've encountered a problem with fetching binary data. Here is an example.

<pre>
def testBinary():
    peacesign_binary = "\xe2\x98\xae"
 
    cnn = dbapi.connect(host = DB_HOST, user = DB_USER,
                            password = DB_PASSWD, db = DB_DB,
                            charset = 'latin-1', use_unicode = True)

    cur = cnn.cursor()
    cur.execute("drop table if exists tblbin")
    cur.execute("create table tblbin (test_id int(11) DEFAULT NULL, test_binary VARBINARY(30) DEFAULT NULL) ENGINE=MyISAM DEFAULT CHARSET=utf8")

    cur.execute("insert into tblbin (test_id, test_binary) values (%s, %s)", (1, peacesign_binary))
    cur.execute("select test_id, test_binary from tblbin")
    result = cur.fetchall()
    self.assertEquals([(1, peacesign_binary)], result)
</pre>

Then, I got an error like this.

<pre>
$ nosetests testmysql.py
..E................

Cursor: ERROR: an error occurred while fetching results
Traceback (most recent call last):
  File "/Users/gonsuke/pyenv/lib/python2.6/site-packages/geventmysql/__init__.py", line 134, in fetchall
    return list(self.result_iter)
  File "/Users/gonsuke/pyenv/lib/python2.6/site-packages/geventmysql/client.py", line 102, in __iter__
    for row in self.connection.reader.read_rows(self.fields):
  File "/Users/gonsuke/pyenv/lib/python2.6/site-packages/geventmysql/mysql.py", line 203, in read_rows
    read_result, rows = reader.read_rows(fields, row_count)
  File "geventmysql._mysql.pyx", line 1024, in geventmysql._mysql.PacketReader.read_rows (lib/geventmysql/geventmysql._mysql.c:10155)
  File "geventmysql._mysql.pyx", line 998, in geventmysql._mysql.PacketReader._read_row (lib/geventmysql/geventmysql._mysql.c:9787)
LookupError: unknown encoding: binary
</pre>


I wrote a patch to solve this problem. Please apply it.
